### PR TITLE
Typo in update-secret-priv-account-v2.ps1

### DIFF
--- a/event-pipelines/update-priv-pipeline-acct/update-secret-priv-account-v2.ps1
+++ b/event-pipelines/update-priv-pipeline-acct/update-secret-priv-account-v2.ps1
@@ -78,7 +78,7 @@ try {
         Id = $secretId
         PrivilegedSecretId = $privSecret.SecretId
     }
-    Set-TssSecretRpcPrivileged @setPrivParmas -ErrorAction Stop
+    Set-TssSecretRpcPrivileged @setPrivParams -ErrorAction Stop
 } catch {
     Write-TssLog -LogFilePath $logFile -MessageType ERROR -Message "[Set-TssSecretRpcPrivileged] issue setting privileged secret to [$($privSecret.SecretName)] on secret [$secretId]"
     throw "[Set-TssSecretRpcPrivileged] issue setting privileged secret to [$($privSecret.SecretName)] on secret [$secretId]"


### PR DESCRIPTION
There's a typo on line 81 of the privileged account event pipeline script where `setPrivParams` was set to `setPrivParmas`. This causes the script to fail and throw an error.